### PR TITLE
feat: add handling of saving and loading length to the .fish file

### DIFF
--- a/save_manager.py
+++ b/save_manager.py
@@ -80,10 +80,21 @@ from tracker import Tracker
 #     },
 #     "fish":
 #     {
-#         track_id_1:
-#             [[frame_1, detection_label_0,[min_x, max_x, min_y, max_y]],
-#             [frame_2, detection_label_1, [min_x, max_x, min_y, max_y]]],
-#         track_id_2: [[frame_2, detection_label_2, [min_x, max_x, min_y, max_y]]]
+#         track_id_1: {
+#             "tracks": [
+#                 [frame_1, detection_label_0, [min_x, max_x, min_y, max_y]],
+#                 [frame_2, detection_label_1, [min_x, max_x, min_y, max_y]]
+#             ],
+#             "length": 1.234,
+#             "length_overwritten": false
+#         },
+#         track_id_2: {
+#             "tracks": [
+#                 [frame_2, detection_label_2, [min_x, max_x, min_y, max_y]]
+#             ],
+#             "length": 0.987,
+#             "length_overwritten": true
+#         }
 #     }
 # }
 


### PR DESCRIPTION
Heyy,

I have added a feature for saving and loading the length parameter of the tracked fish in the JSON-file. It also handles the case where the `*.fish` file does not have the length property. In order to test the feature I have done the following:

1. Created a `*.fish` file by running `uv run batch_track_cli.py` 
2. Opened the UI `uv run main.py`
3. Loaded the `*.fish`-file in the UI (File > Load > Choosen the new `*.fish` file).
4. I have also tested with another `*.fish`-file to check if it can interpret a file which does not have the length property