### PR TITLE
fix: mismatch in frame_id in files vs. UI

### DIFF
--- a/detector.py
+++ b/detector.py
@@ -393,7 +393,7 @@ class Detector(QtCore.QObject):
                         continue
 
                     row = {
-                        "frame": frame,
+                        "frame": frame + 1,  # convert to 1-indexed to match UI display
                         "length": d.length,
                         "distance": d.distance,
                         "angle": d.angle,
@@ -458,9 +458,10 @@ class Detector(QtCore.QObject):
 
                 for line in file:
                     split_line = line.split(";")
-                    frame = int(split_line[0])
+                    # Convert from 1-indexed to 0-indexed
+                    frame = int(split_line[0]) - 1
 
-                    if frame >= nof_frames:
+                    if frame >= nof_frames or frame < 0:
                         ignored_dets += 1
                         continue
 

--- a/fish_manager.py
+++ b/fish_manager.py
@@ -848,7 +848,7 @@ class FishManager(QtCore.QAbstractTableModel):
                         flat_corners.extend(["", ""])
                 row = [
                     fish.id,
-                    frame,
+                    frame + 1,  # convert to 1-indexed to match UI display
                     f1.format(length),
                     f1.format(distance),
                     f1.format(angle),
@@ -881,7 +881,8 @@ class FishManager(QtCore.QAbstractTableModel):
                 for line in file:
                     split_line = line.split(";")
                     id = int(split_line[0])
-                    frame = int(split_line[1])
+                    # Convert from 1-indexed to 0-indexed
+                    frame = int(split_line[1]) - 1
                     length = float(split_line[2])
                     aspect = float(split_line[5])
                     direction = SwimDirection[split_line[6]]


### PR DESCRIPTION
Hey, 

I have taken a closer look at #7 which states there is a mismatch between the `frame_id` in the written files and the `frame_id` displayed in the UI. I wasn't sure if I was supposed to correct the ID shown in the UI or in the files being written, but I chose the latter. 

The files are now being saved with `frame_id` from 1 and up.